### PR TITLE
use provided config

### DIFF
--- a/clerk_timestamp.py
+++ b/clerk_timestamp.py
@@ -15,7 +15,7 @@ def append_timestamp(
         if not "format" in extension_config
         else extension_config["format"]
     )
-    prefix = "\n[" if not prefix in extension_config else extension_config["prefix"]
-    suffix = "] " if not suffix in extension_config else extension_config["suffix"]
+    prefix = "\n[" if not 'prefix' in extension_config else extension_config["prefix"]
+    suffix = "] " if not 'suffix' in extension_config else extension_config["suffix"]
     now = get_timestamp(stamp_format)
     return file_contents + [f"{prefix}{now}{suffix}"]

--- a/clerk_timestamp.py
+++ b/clerk_timestamp.py
@@ -1,6 +1,21 @@
 import datetime
+from typing import Mapping
 from typing import Sequence
 
 
-def append_timestamp(file_contents: Sequence[str]) -> Sequence[str]:
-    return file_contents + [f"[{datetime.datetime.now().isoformat()}] "]
+def get_timestamp(stamp_format: str = "%Y-%m-%d %H:%M:%S"):
+    return datetime.datetime.now().strftime(stamp_format)
+
+
+def append_timestamp(
+    file_contents: Sequence[str], extension_config: Mapping = {}
+) -> Sequence[str]:
+    stamp_format = (
+        "%Y-%m-%d %H:%M:%S"
+        if not "format" in extension_config
+        else extension_config["format"]
+    )
+    prefix = "\n[" if not prefix in extension_config else extension_config["prefix"]
+    suffix = "] " if not suffix in extension_config else extension_config["suffix"]
+    now = get_timestamp(stamp_format)
+    return file_contents + [f"{prefix}{now}{suffix}"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = josephhaaga-clerk-timestamp
-version = 0.0.2
+version = 0.0.3
 author = Joseph Haaga
 author_email = haaga.joe@gmail.com
 description = Appends timestamps to your clerk journal entries
@@ -17,12 +17,14 @@ classifiers =
 [options]
 py_modules=clerk_timestamp
 python_requires = >=3.7
+install_requires =
+    josephhaaga-clerk>=0.0.3
 
 [options.entry_points]
 clerk.extensions =
     timestamp = clerk_timestamp:append_timestamp
 console_scripts = 
-    clerk-timestamp = clerk_timestamp:append_timestamp
+    clerk-timestamp = clerk_timestamp:get_timestamp
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
`clerk` v0.0.3 will provide configuration info to hooks - this PR updates `clerk-timestamp` to read the following optional items from the clerk config

- `prefix`
- `suffix`
- `format`

So a config that looks like this
```
[DEFAULT]
...

[hooks]
JOURNAL_OPENED =
    timestamp


[clerk-timestamp]
format=%%Y-%%m-%%d %%I:%%M:%%S %%p
prefix=\n[
suffix=] 
```

Should append the following timestamp on journal entry

```
...

[2021-06-22 07:39:35] 
```